### PR TITLE
Support Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use tokio::io::{AsyncRead, AsyncSeek, ReadBuf, SeekFrom};
 use tokio_util::io::StreamReader;
 
 type SReader =
-    StreamReader<Pin<Box<dyn futures::Stream<Item = Result<Bytes, IoError>> + Send>>, Bytes>;
+    StreamReader<Pin<Box<dyn futures::Stream<Item = Result<Bytes, IoError>> + Send + Sync>>, Bytes>;
 
 /// A continuously streaming, seekable HTTP reader.
 /// Only on `seek` does it drop the connection and open a new ranged request.
@@ -27,7 +27,7 @@ where
     pub position: u64,
 
     // In-flight response future when opening connection
-    init_fetch: Option<Pin<Box<dyn futures::Future<Output = IoResult<Response>> + Send>>>,
+    init_fetch: Option<Pin<Box<dyn futures::Future<Output = IoResult<Response>> + Send + Sync>>>,
     // Once the response is ready, this yields chunks
     reader: Option<SReader>,
 }


### PR DESCRIPTION
Some frameworks like https://github.com/tauri-apps/tauri (`#[tauri::command]`) need `Sync` to work.

Before this PR, the error is

```
dyn Future<Output = Result<Response, Error>> + Send` cannot be shared between threads safely the trait `Sync` is not implemented for `dyn Future<Output = Result<Response, Error>> + Send`

required for `Unique<dyn Future<Output = Result<Response, Error>> + Send>` to implement `Sync`
required for `&Seekable<{closure@src/lib.rs:136:36: 136:43}>` to implement `std::marker::Send
```